### PR TITLE
Plugin installation fixes

### DIFF
--- a/src/Api/DB.php
+++ b/src/Api/DB.php
@@ -179,8 +179,15 @@ class DB {
 
 		$current_db_version = (float) get_option( 'caldera_forms_civicrm_redirect_db_version', false );
 
-		if ( $current_db_version != $this->db_version )
+		// Create tables on first install.
+		if ( empty( $current_db_version ) ) {
 			$this->create_tables();
+		}
+
+		// Update db version when it changes.
+		if ( $current_db_version != $this->db_version ) {
+			update_option( 'caldera_forms_civicrm_redirect_db_version', $this->db_version );
+		}
 
 	}
 

--- a/src/Api/DB.php
+++ b/src/Api/DB.php
@@ -179,9 +179,10 @@ class DB {
 
 		$current_db_version = (float) get_option( 'caldera_forms_civicrm_redirect_db_version', false );
 
-		// Create tables on first install.
+		// Tasks to perform on first install.
 		if ( empty( $current_db_version ) ) {
 			$this->create_tables();
+			$this->flush_civicrm_cache();
 		}
 
 		// Update db version when it changes.
@@ -219,6 +220,37 @@ class DB {
 		dbDelta( $sql );
 
 		return empty( $this->wpdb->last_error );
+
+	}
+
+	/**
+	 * Clear CiviCRM caches.
+	 *
+	 * Another way to do this might be:
+	 * CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+	 *
+	 * @since 0.4
+	 */
+	public function flush_civicrm_cache() {
+
+		// Bail if no CiviCRM.
+		if ( ! civi_wp()->initialize() ) return;
+
+		// Access config object.
+		$config = \CRM_Core_Config::singleton();
+
+		// Clear database cache.
+		$config->clearDBCache();
+
+		// Cleanup the "templates_c" directory.
+		$config->cleanup( 1, true );
+
+		// Cleanup the session object.
+		$session = \CRM_Core_Session::singleton();
+		$session->reset( 1 );
+
+		// Call system flush.
+		\CRM_Utils_System::flushCache();
 
 	}
 


### PR DESCRIPTION
This PR does a couple of things:

#### 1) Prevents `dbDelta()` from running on every page load

Currently the following two database queries are performed on every admin page load:

```
ALTER TABLE wp_cfc_redirects CHANGE COLUMN `entity_id` entity_id bigint(20) UNSIGNED NOT NULL
ALTER TABLE wp_cfc_redirects CHANGE COLUMN `post_id` post_id bigint(20) UNSIGNED NOT NULL
```

This is because the plugin's database version is not stored, so `create_tables()` is always called. The first commit in this PR stores the database version, preventing this from happening.

#### 2) Clears CiviCRM's cache on initial install.

Currently the form on the "Caldera Forms Redirect" tab of a CiviCRM Event's configuration page is not correctly displayed. Clearing the cache solves this.